### PR TITLE
Fix container.lookup deprecation

### DIFF
--- a/addon/instance-initializers/liquid-target-container.js
+++ b/addon/instance-initializers/liquid-target-container.js
@@ -1,7 +1,7 @@
 export function initialize(instance) {
   let liquidTargetContainer;
   
-  if (instance.lookup)
+  if (instance.lookup) {
     liquidTargetContainer = instance.lookup('component:liquid-target-container');
   } else {
     liquidTargetContainer = instance.container.lookup('component:liquid-target-container');

--- a/addon/instance-initializers/liquid-target-container.js
+++ b/addon/instance-initializers/liquid-target-container.js
@@ -1,6 +1,11 @@
 export function initialize(instance) {
-  const lookup = instance.lookup || instance.container.lookup;
-  const liquidTargetContainer = lookup('component:liquid-target-container');
+  let liquidTargetContainer;
+  
+  if (instance.lookup)
+    liquidTargetContainer = instance.lookup('component:liquid-target-container');
+  } else {
+    liquidTargetContainer = instance.container.lookup('component:liquid-target-container');
+  }
 
   liquidTargetContainer.appendTo(instance.rootElement);
 }

--- a/addon/instance-initializers/liquid-target-container.js
+++ b/addon/instance-initializers/liquid-target-container.js
@@ -1,5 +1,6 @@
 export function initialize(instance) {
-  const liquidTargetContainer = instance.container.lookup('component:liquid-target-container');
+  const lookup = instance.lookup || instance.container.lookup;
+  const liquidTargetContainer = lookup('component:liquid-target-container');
 
   liquidTargetContainer.appendTo(instance.rootElement);
 }


### PR DESCRIPTION
Ember 2.x deprecated the lookup on the container directly, so we need to have a fallback for 1.x now to avoid the deprecation.

Resolves #21