### PR TITLE
Add `on-overlay-click` action

### DIFF
--- a/addon/components/liquid-tether.js
+++ b/addon/components/liquid-tether.js
@@ -99,5 +99,13 @@ export default LiquidWormhole.extend({
       }
     });
     return options;
+  },
+
+  actions: {
+    clickOverlay() {
+      if (this.get('overlayClick')) {
+        this.sendAction('overlayClick');
+      }
+    }
   }
 });

--- a/addon/components/liquid-tether.js
+++ b/addon/components/liquid-tether.js
@@ -103,8 +103,8 @@ export default LiquidWormhole.extend({
 
   actions: {
     clickOverlay() {
-      if (this.get('overlayClick')) {
-        this.sendAction('overlayClick');
+      if (this.get('on-overlay-click')) {
+        this.sendAction('on-overlay-click');
       }
     }
   }

--- a/addon/templates/components/liquid-tether.hbs
+++ b/addon/templates/components/liquid-tether.hbs
@@ -1,4 +1,4 @@
-<div class="liquid-tether-overlay {{overlayClass}}"></div>
+<div class="liquid-tether-overlay {{overlayClass}} {{if overlayClick 'clickable'}}" {{action 'clickOverlay'}}></div>
 <div class="liquid-tether {{tetherClass}}">
   {{yield}}
 </div>

--- a/addon/templates/components/liquid-tether.hbs
+++ b/addon/templates/components/liquid-tether.hbs
@@ -1,4 +1,4 @@
-<div class="liquid-tether-overlay {{overlayClass}} {{if overlayClick 'clickable'}}" {{action 'clickOverlay'}}></div>
+<div class="liquid-tether-overlay {{overlayClass}} {{if on-overlay-click 'clickable'}}" {{action 'clickOverlay'}}></div>
 <div class="liquid-tether {{tetherClass}}">
   {{yield}}
 </div>

--- a/tests/acceptance/demo-test.js
+++ b/tests/acceptance/demo-test.js
@@ -84,3 +84,18 @@ test('routed tethers can determine context', function() {
   andThen(() => ranTetherTransition('fade'));
   andThen(() => ranOverlayTransition('fade'));
 });
+
+test('clickable overlay responds and has correct class', function() {
+  visit('/examples');
+
+  click('#animation-with-context-button');
+  andThen(() => ranTetherTransition('fade'));
+  andThen(() => ranOverlayTransition('fade'));
+  andThen(() => {
+    equal(find('.liquid-tether-overlay.clickable').length, 1, 'clickable overlay exists');
+  });
+
+  click('.liquid-tether-overlay.clickable');
+  andThen(() => ranTetherTransition('fade'));
+  andThen(() => ranOverlayTransition('fade'));
+});

--- a/tests/dummy/app/templates/basics.hbs
+++ b/tests/dummy/app/templates/basics.hbs
@@ -45,7 +45,7 @@
 
 <ul>
   <li>
-    <strong>overlayClick</strong>: Action for handling clicking of the overlay. If the
+    <strong>on-overlay-click</strong>: Action for handling clicking of the overlay. If the
     action is specified, the overlay also gets an additional class, i.e. 'clickable'.
   </li>
 </ul>

--- a/tests/dummy/app/templates/basics.hbs
+++ b/tests/dummy/app/templates/basics.hbs
@@ -19,7 +19,7 @@
 {{/scroll-spier}}
 
 <p>
-  Every Liquid Tether requires the following attributes:
+  Every Liquid Tether <strong>requires</strong> the following attributes:
 </p>
 
 <ul>
@@ -35,6 +35,18 @@
   <li>
     <strong>attachment</strong>: The attachment point on the tethered
     element.
+  </li>
+</ul>
+
+<p>
+  Apart from the above required attributes, there is also one <strong>optional</strong>
+  attribute:
+</p>
+
+<ul>
+  <li>
+    <strong>overlayClick</strong>: Action for handling clicking of the overlay. If the
+    action is specified, the overlay also gets an additional class, i.e. 'clickable'.
   </li>
 </ul>
 

--- a/tests/dummy/app/templates/examples.hbs
+++ b/tests/dummy/app/templates/examples.hbs
@@ -75,7 +75,8 @@
     targetModifier="visible"
     attachment="middle center"
     tetherClass="modal-dialog"
-    overlayClass="modal-backdrop"}}
+    overlayClass="modal-backdrop"
+    on-overlay-click="closeModalDialog"}}
     <div class="modal-content">
       <div class="modal-header">
         <h4 class="modal-title">Modal Header</h4>


### PR DESCRIPTION
This allows closing the liquid-tether when clicking the overlay.
This action is optional, and if it is specified, the overlay element gets
an additional class: 'clickable', so that it can be styled appropriately.

Resolves #26 