### PR TITLE
Add a 'has-targets' class to container

### DIFF
--- a/addon/components/liquid-target-container.js
+++ b/addon/components/liquid-target-container.js
@@ -1,12 +1,14 @@
 import Ember from 'ember';
 import layout from '../templates/components/liquid-target-container';
 
-const { inject } = Ember;
+const { inject, computed } = Ember;
 const { service } = inject;
 
 export default Ember.Component.extend({
   layout: layout,
   classNames: ['liquid-target-container'],
+  classNameBindings: ['hasTargets'],
 
+  hasTargets: computed.bool('liquidTargetService.targets.length'),
   liquidTargetService: service('liquid-target')
 });

--- a/tests/acceptance/scenarios-test.js
+++ b/tests/acceptance/scenarios-test.js
@@ -62,6 +62,16 @@ test('target only shows one tether at a time', function() {
   });
 });
 
+test('container has correct class if targets are present', function() {
+  ok(find('.liquid-target-container.has-targets').length === 0, 'No targets class');
+
+  visit('/scenarios/multiple-tethers');
+
+  andThen(() => {
+    ok(find('.liquid-target-container.has-targets').length > 0, 'Has targets class');
+  });
+});
+
 function withinTolerance(offset1, offset2) {
   return Math.abs(offset1 - offset2) <= 3;
 }


### PR DESCRIPTION
This allows styling the container to fill the page, and allow overflow
to be applied as a style. Great way to handle scrollable modals.

This works with `{{liquid-wormhole}}` as well as `{{liquid-tether}}`.