### PR TITLE
Update broccoli funnel and merge-trees

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "ember-addon"
   ],
   "dependencies": {
-    "broccoli-funnel": "^0.2.8",
-    "broccoli-merge-trees": "^0.2.3",
+    "broccoli-funnel": "^1.1.0",
+    "broccoli-merge-trees": "^1.2.4",
     "liquid-wormhole": "^2.0.2",
     "tether": "^1.4.0",
     "ember-cli-htmlbars": "^1.0.10",


### PR DESCRIPTION
I'm on a quest to get rid of minimatch deprecation warnings.  This update eliminates one.